### PR TITLE
Fix segfault in time parsing

### DIFF
--- a/readv1.c
+++ b/readv1.c
@@ -73,7 +73,11 @@ debug("status file is %s",STATUS_FILE);
       STATUS_FILE);
     exit(1);
   }
-  strncpy(last_update,ctime((time_t *)&last_update_int),20);
+  {
+    // Copy the value in case int is a different size to time_t
+    time_t last_update_time = last_update_int;
+    strncpy(last_update,ctime(&last_update_time),20);
+  }
   last_update[21] = '\0';
 
   /*--------------------------------------------------------*/
@@ -129,7 +133,11 @@ debug("status file is %s",STATUS_FILE);
               sscanf(str_match,"%d",&stamp);
               host_list[host_list_size][LAST_STATE_CHANGE_INT] = (char *)stamp;
               host_list[host_list_size][LAST_STATE_CHANGE] = malloc(17); /* "DOW Mon DD HH:MM\0" */
-              strncpy(host_list[host_list_size][LAST_STATE_CHANGE],ctime((time_t *)&stamp),16);
+              {
+                // Copy the value in case int is a different size to time_t
+                time_t stamp_time = stamp;
+                strncpy(host_list[host_list_size][LAST_STATE_CHANGE],ctime(&stamp_time),16);
+              }
               host_list[host_list_size][DURATION] = (char *)calc_duration(stamp);
             }
           break;
@@ -199,7 +207,11 @@ debug("status file is %s",STATUS_FILE);
             } else {
               sscanf(str_match,"%d",&stamp);
               service_list[service_list_size][LAST_STATE_CHANGE_INT] = (char *)stamp;
-              strncpy(service_list[service_list_size][LAST_STATE_CHANGE],ctime((time_t *)&stamp),16);
+              {
+                // Copy the value in case int is a different size to time_t
+                time_t stamp_time = stamp;
+                strncpy(service_list[service_list_size][LAST_STATE_CHANGE],ctime(&stamp_time),16);
+              }
               service_list[service_list_size][DURATION] = (char *)calc_duration(stamp);
             }
           break;

--- a/readv23.c
+++ b/readv23.c
@@ -89,7 +89,11 @@ debug("status file is %s",STATUS_DAT_FILE);
   }
   if ( !strcmp(ent.lhs,"created") ) {
     last_update_int = atoi(ent.rhs);
-    strncpy(last_update,ctime((time_t *)&last_update_int),19);
+    {
+      // Copy the value in case int is a different size to time_t
+      time_t last_update_time = last_update_int;
+      strncpy(last_update,ctime(&last_update_time),19);
+    }
     last_update[20] = '\0';
   } else {
     endwin();
@@ -244,7 +248,11 @@ debug("  current_state is PENDING, inferred from empty plugin output on Jan 1 19
       } else { 
         host_list[host_list_size][LAST_STATE_CHANGE_INT] = (char *)host_stamp;
         host_list[host_list_size][LAST_STATE_CHANGE] = malloc(17); /* "DOW Mon DD HH:MM\0" */
-        strncpy(host_list[host_list_size][LAST_STATE_CHANGE],ctime((time_t *)&host_stamp),16);
+        {
+          // Copy the value in case int is a different size to time_t
+          time_t host_stamp_time = host_stamp;
+          strncpy(host_list[host_list_size][LAST_STATE_CHANGE],ctime(&host_stamp_time),16);
+        }
       }
       host_list[host_list_size][LAST_STATE_CHANGE][16] = '\0';
 #ifdef _DEBUG_
@@ -413,7 +421,11 @@ debug("  current_state is %s",service_list[service_list_size][STATUS]);
       sscanf(ent.rhs,"%d",&service_stamp);
       service_list[service_list_size][LAST_STATE_CHANGE_INT] = (char *)service_stamp;
       service_list[service_list_size][LAST_STATE_CHANGE] = malloc(17); /* "DOW Mon DD HH:MM\0" */
-      strncpy(service_list[service_list_size][LAST_STATE_CHANGE],ctime((time_t *)&service_stamp),16);
+      {
+        // Copy the value in case int is a different size to time_t
+        time_t service_stamp_time = service_stamp;
+        strncpy(service_list[service_list_size][LAST_STATE_CHANGE],ctime(&service_stamp_time),16);
+      }
       service_list[service_list_size][LAST_STATE_CHANGE][16] = '\0';
 #ifdef _DEBUG_
 debug("  last_state_change is \"%s\" (%d)",


### PR DESCRIPTION
On systems where `sizeof(time_t) > sizeof(int)`, attempting to dereference the stamp time variables as `(time_t*)` will return an incorrect value, which in turn can cause `ctime` to return `NULL`.
